### PR TITLE
return expr ; -> return expr? ;

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ toplevel   = types ident "(" funcParams? ")" block
            | comment
 block      = "{" stmt* "}"
 stmt       =  expr ";"
-           | "return" expr ";"
+           | "return" expr? ";"
            | "if" "(" expr ")" block ("else" block)?
            | "while" "(" expr ")" block
            | "for" "(" expr? ";" expr? ";" expr? ")" block

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -120,6 +120,11 @@ func stmt() (*Node, error) {
 	}
 
 	if return_ := consumeIdent("return"); return_ != nil {
+		if consume(tokenize.Semi) != nil {
+			node = NewNodeReturn(return_.Pos, nil)
+			return node, nil
+		}
+
 		n, err := expr()
 		if err != nil {
 			return nil, err

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -285,6 +285,28 @@ void main() { var a int; a = 1; var b int = 2; c := 3; }`,
 			},
 			nil,
 		},
+		{
+			"main, direct return",
+			"void main() { return; }",
+			[]*Node{
+				NewNodeFunctionDefine(
+					GenPosForTest(""),
+					NewNodeWithChildren(GenPosForTest(""), Void, nil),
+					NewNodeIdent(GenPosForTest("void "), "main"),
+					nil,
+					NewNodeWithChildren(
+						GenPosForTest("void main() "),
+						Block,
+						[]*Node{
+							NewNodeReturn(
+								GenPosForTest("void main() { "),
+								nil),
+						},
+					),
+				),
+			},
+			nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
voidキーワードをサポートしているにも関わらず、returnで何かを返すことが必須になっていた不具合を修正