### PR TITLE
fix primary to unary

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ callArgs   = expr ("," expr)*
 funcParams = ident types ("," ident types)*
 
 
-list = "[" primary? "]"
-      | "[" primary ("," primary)* "]"
+list = "[" unary? "]"
+      | "[" unary ("," unary)* "]"
 
 dict  = "{" kv? "}"
       | "{" kv ("," kv)* "}"
-kv    = string ":" primary
+kv    = string ":" unary
 
 ident   = [a-zA-Z_][a-zA-Z0-9_]*
 float   = [0-9]+[0-9.][0-9]+

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -705,7 +705,7 @@ func list() (*Node, error) {
 	var nodes []*Node
 
 	for consume(tokenize.Rsb) == nil {
-		n, err := primary()
+		n, err := unary()
 		if err != nil {
 			return nil, err
 		}
@@ -752,7 +752,7 @@ func kv() (*Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	value, err := primary()
+	value, err := unary()
 	if err != nil {
 		return nil, err
 	}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -307,6 +307,40 @@ void main() { var a int; a = 1; var b int = 2; c := 3; }`,
 			},
 			nil,
 		},
+		{
+			"list",
+			"void main() { return [-2]; }",
+			[]*Node{
+				NewNodeFunctionDefine(
+					GenPosForTest(""),
+					NewNodeWithChildren(GenPosForTest(""), Void, nil),
+					NewNodeIdent(GenPosForTest("void "), "main"),
+					nil,
+					NewNodeWithChildren(
+						GenPosForTest("void main() "),
+						Block,
+						[]*Node{
+							NewNodeReturn(
+								GenPosForTest("void main() { "),
+								NewNodeWithChildren(
+									GenPosForTest("void main() { return "),
+									List,
+									[]*Node{
+										NewNode(
+											GenPosForTest("void main() { return ["),
+											Minus,
+											NewNodeImmediate(
+												GenPosForTest("void main() { return [-"),
+												&tokenize.Token{Kind: tokenize.Int, I: 2}),
+											nil,
+										),
+									})),
+						},
+					),
+				),
+			},
+			nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
listのitem, dictのvalueにprimaryが設定されていたことで、明示的にプラスが付けられた値、マイナスの値、否定記号のついた値を使用することができなかった問題を修正